### PR TITLE
Issue 35 remove hardcoded links

### DIFF
--- a/backend/ddueruemweb/settings.py
+++ b/backend/ddueruemweb/settings.py
@@ -9,8 +9,11 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
-import os
+import os, environ
 from pathlib import Path
+
+env = environ.Env(DEBUG=(bool, False))
+environ.Env.read_env()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -19,10 +22,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-1ui7v_-4226d=v3%_25g+#kounltqcnxw3++c*tvy1h6cfq_=2'
+SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = env('DEBUG')
 
 ALLOWED_HOSTS = []
 
@@ -81,6 +84,7 @@ WSGI_APPLICATION = 'ddueruemweb.wsgi.application'
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
 DATABASES = {
+    # Should be in the environment as well
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': BASE_DIR / 'db.sqlite3',
@@ -153,10 +157,10 @@ CORS_ALLOWED_ORIGINS = [
 ]
 
 # https://docs.djangoproject.com/en/3.2/topics/email/
-EMAIL_HOST = "localhost"  # define host and port for email backend
+EMAIL_HOST = env('EMAIL_HOST')  # define host and port for email backend
 # EMAIL_HOST_USER="backend"
 # EMAIL_HOST_PASSWORD="123"
-EMAIL_PORT = 1025
+EMAIL_PORT = env('EMAIL_PORT')
 # EMAIL_USE_TLS = True
 # EMAIL_USE_SSL = False
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,13 @@
 asgiref==3.4.1
 Django==3.2.8
 django-cors-headers==3.10.0
-django-rest-auth==0.9.5
+django-crispy-forms==1.13.0
+django-environ==0.8.1
 django-extensions==3.1.5
+django-rest-auth==0.9.5
 djangorestframework==3.12.4
 djangorestframework-simplejwt==5.0.0
+PyJWT==2.3.0
 pytz==2021.3
+six==1.16.0
 sqlparse==0.4.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,13 +1,10 @@
 asgiref==3.4.1
 Django==3.2.8
 django-cors-headers==3.10.0
-django-crispy-forms==1.13.0
 django-environ==0.8.1
 django-extensions==3.1.5
 django-rest-auth==0.9.5
 djangorestframework==3.12.4
 djangorestframework-simplejwt==5.0.0
-PyJWT==2.3.0
 pytz==2021.3
-six==1.16.0
 sqlparse==0.4.2

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+DOMAIN=http://localhost:8000

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-DOMAIN=http://localhost:8000
+REACT_APP_DOMAIN="http://localhost:8000/"

--- a/frontend/.env.testing
+++ b/frontend/.env.testing
@@ -1,0 +1,1 @@
+DOMAIN=http://localhost:8000/

--- a/frontend/.env.testing
+++ b/frontend/.env.testing
@@ -1,1 +1,1 @@
-DOMAIN=http://localhost:8000/
+REACT_APP_DOMAIN="http://localhost:8000/"

--- a/frontend/src/routes/Upload.tsx
+++ b/frontend/src/routes/Upload.tsx
@@ -69,7 +69,7 @@ export default class upload extends Component<Props, State> {
       data.append("license", this.state.license);
 
       api
-        .post("http://localhost:8000/files/", data, {
+        .post(`${process.env.DOMAIN}/files/`, data, {
           headers: { "Content-Type": "multipart/form-data" },
         })
         .then((result) => {

--- a/frontend/src/services/api.service.ts
+++ b/frontend/src/services/api.service.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import authService from "./auth.service";
 
+const API_URL = process.env.REACT_APP_DOMAIN;
+
 //axios instance for checking if token is (still) valid.
 const instance = axios.create({
-  baseURL: "http://localhost:8000/",
+  baseURL: API_URL,
   headers: {
     "Content-Type": "application/json",
   },
@@ -40,12 +42,9 @@ instance.interceptors.response.use(
     if (error.response && error.response.status === 401) {
       try {
         // Use axios not an instance to prevent infinite loops
-        const response = await axios.post(
-          "http://localhost:8000/auth/refresh/",
-          {
-            refresh: authService.getRefreshToken(),
-          }
-        );
+        const response = await axios.post(API_URL + "auth/refresh/", {
+          refresh: authService.getRefreshToken(),
+        });
 
         const accessToken = response.data.access;
         localStorage.setItem("access", JSON.stringify(accessToken));

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const API_URL = process.env.REACT_APP_DOMAIN + "/auth";
+const API_URL = process.env.REACT_APP_DOMAIN + "auth/";
 
 console.log(process.env.REACT_APP_DOMAIN);
 

--- a/frontend/src/services/auth.service.ts
+++ b/frontend/src/services/auth.service.ts
@@ -1,6 +1,8 @@
 import axios from "axios";
 
-const API_URL = "http://localhost:8000/auth/";
+const API_URL = process.env.REACT_APP_DOMAIN + "/auth";
+
+console.log(process.env.REACT_APP_DOMAIN);
 
 class AuthService {
   login(email: string, password: string) {


### PR DESCRIPTION
Hardcoded links were removed. Every important constant which differs between development and production or is security relevant should now be in:

**DJANGO:**
`./backend/ddueruemweb/.env` (There is an examplefile provided with the .env.example)

**React:**
`./frontend/src/.env.development` React automatically uses `.env.development` when started with `yarn build`, `.env.testing` when started for testing and `.env.production` when built for production

These `.env` files can be used for an easy CD process. For instance, having the `.env.production` on the server and supplying it with a volume

- This closes #35 