### PR TITLE
Issue 52

### DIFF
--- a/backend/core/user/models.py
+++ b/backend/core/user/models.py
@@ -63,7 +63,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     is_active = models.BooleanField(default=False)
     is_staff = models.BooleanField(default=False)
     date_joined = models.DateTimeField('date joined', auto_now_add=True, editable=False)
-    institute = models.CharField(db_index=True, max_length=255, unique=False)
+    institute = models.CharField(max_length=255, unique=False, blank=True)
     bio = models.TextField(max_length=500, blank=True)
 
     USERNAME_FIELD = 'email'

--- a/backend/core/user/viewsets.py
+++ b/backend/core/user/viewsets.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.signing import BadSignature
 from django.utils import timezone, dateparse
+from django.utils.encoding import DjangoUnicodeDecodeError
 from rest_framework.response import Response
 from core.user.serializers import UserSerializer
 from core.user.models import User
@@ -49,4 +50,6 @@ class ActivateUserViewSet(GenericViewSet, CreateModelMixin):
         except ObjectDoesNotExist as error:
             return Response({'message': str(error)})
         except BadSignature as error:
+            return Response({'message': str(error)})
+        except DjangoUnicodeDecodeError as error:
             return Response({'message': str(error)})


### PR DESCRIPTION
When accessing  `http://localhost:8000/auth/register/confirm/<someToken>` the page does not crash anymore if the token could not be parsed

You can check this by registring a new user, copy the activation link from the email and alter the token inside the link