### PR TITLE
Issue 116 sonarqube per branch

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -175,7 +175,7 @@ jobs:
         path: ${{ github.workspace }}/backend
         
     - name: Set Sonarqube Project Name
-      run: |
+      run: >
         slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
           minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
           sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" ${{ github.workspace }}/backend/sonar-project.properties

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,8 +176,9 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-backend\-${{ github.ref }}}/" sonar-project.properties
-        # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
+        slashreplace=`${{ github.ref }} | sed -r 's/[\/]+/\\\//g'`
+        minusreplace=`$slashreplace | sed -r 's/[\-]+/\\\-/g'`
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,8 +176,8 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        slashreplace=`${{ github.ref }} | sed -r 's/[\/]+/\\\//g'`
-        minusreplace=`$slashreplace | sed -r 's/[\-]+/\\\-/g'`
+        slashreplace=`"${{ github.ref }}" | sed -r 's/[\/]+/\\\//g'`
+        minusreplace=`"$slashreplace" | sed -r 's/[\-]+/\\\-/g'`
         sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" sonar-project.properties
         
     - name: SonarQube Scan

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,9 +176,9 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g')
-        minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g')
-        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" sonar-project.properties
+        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
+          minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
+          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,10 +1,6 @@
 name: Django CI
 
-on:
-  push:
-    branches: [dev, issue-116-sonarqube-per-branch]
-  pull_request:
-    branches: [dev, issue-116-sonarqube-per-branch]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,8 +176,8 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        slashreplace=`"${{ github.ref }}" | sed -r 's/[\/]+/\\\//g'`
-        minusreplace=`"$slashreplace" | sed -r 's/[\-]+/\\\-/g'`
+        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g')
+        minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g')
         sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" sonar-project.properties
         
     - name: SonarQube Scan

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,7 +176,7 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g' | sed -r 's/[-]+/\\\-/g')/" ${{ github.workspace }}/backend/sonar-project.properties
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$(echo "${{ github.ref_name }}" | sed -r 's/[\/]+/_/g' | sed -r 's/[-]+/\\\-/g')/" ${{ github.workspace }}/backend/sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,7 +176,7 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem-web-backend-${{ github.ref }}}/" sonar-project.properties
+        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-backend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,7 +176,8 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
+        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem-web-backend-${{ github.ref }}}/" sonar-project.properties
+        # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -2,9 +2,9 @@ name: Django CI
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, issue-116-sonarqube-per-branch]
   pull_request:
-    branches: [dev]
+    branches: [dev, issue-116-sonarqube-per-branch]
 
 jobs:
 
@@ -173,6 +173,10 @@ jobs:
       with:
         name: sonar-coverage-backend
         path: ${{ github.workspace }}/backend
+        
+    - name: Set Sonarqube Project Name
+      run: |
+        sed -ir "s/^[#]*\s*sonar.projectKey=.*/sonar.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -176,7 +176,7 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -ir "s/^[#]*\s*sonar.projectKey=.*/sonar.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-backend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -175,10 +175,8 @@ jobs:
         path: ${{ github.workspace }}/backend
         
     - name: Set Sonarqube Project Name
-      run: >
-        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
-          minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
-          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" ${{ github.workspace }}/backend/sonar-project.properties
+      run: |
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g' | sed -r 's/[-]+/\\\-/g')/" ${{ github.workspace }}/backend/sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -178,7 +178,7 @@ jobs:
       run: |
         slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
           minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
-          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" sonar-project.properties
+          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-backend\-$minusreplace/" ${{ github.workspace }}/backend/sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,8 +167,8 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        slashreplace=`${{ github.ref }} | sed -r 's/[\/]+/\\\//g'`
-        minusreplace=`$slashreplace | sed -r 's/[\-]+/\\\-/g'`
+        slashreplace=`"${{ github.ref }}" | sed -r 's/[\/]+/\\\//g'`
+        minusreplace=`"$slashreplace" | sed -r 's/[\-]+/\\\-/g'`
         sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" sonar-project.properties
         # sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -169,7 +169,7 @@ jobs:
       run: |
         slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
           minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
-          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" sonar-project.properties
+          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" ${{ github.workspace }}/frontend/sonar-project.properties
         # sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,9 +167,9 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g')
-        minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g')
-        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" sonar-project.properties
+        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
+          minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
+          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" sonar-project.properties
         # sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,11 +3,7 @@
 
 name: Node.js CI
 
-on:
-  push:
-    branches: [dev, issue-116-sonarqube-per-branch]
-  pull_request:
-    branches: [dev, issue-116-sonarqube-per-branch]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,7 +167,10 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
+        slashreplace=`${{ github.ref }} | sed -r 's/[\/]+/\\\//g'`
+        minusreplace=`$slashreplace | sed -r 's/[\-]+/\\\-/g'`
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" sonar-project.properties
+        # sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -166,7 +166,7 @@ jobs:
         sed -i 's/\/home\/runner\/work\/ddueruem-web\/ddueruem-web\//\/github\/workspace\//g' sonar-report.xml
         
     - name: Set Sonarqube Project Name
-      run: |
+      run: >
         slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
           minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
           sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" ${{ github.workspace }}/frontend/sonar-project.properties

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [dev]
+    branches: [dev, issue-116-sonarqube-per-branch]
   pull_request:
-    branches: [dev]
+    branches: [dev, issue-116-sonarqube-per-branch]
 
 jobs:
 
@@ -164,6 +164,10 @@ jobs:
       run: |
         sed -i 's/\/home\/runner\/work\/ddueruem-web\/ddueruem-web\//\/github\/workspace\//g' coverage/lcov.info
         sed -i 's/\/home\/runner\/work\/ddueruem-web\/ddueruem-web\//\/github\/workspace\//g' sonar-report.xml
+        
+    - name: Set Sonarqube Project Name
+      run: |
+        sed -ir "s/^[#]*\s*sonar.projectKey=.*/sonar.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,7 +167,7 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-frontend\-$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g' | sed -r 's/[-]+/\\\-/g')/" ${{ github.workspace }}/frontend/sonar-project.properties
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-frontend\-$(echo "${{ github.ref_name }}" | sed -r 's/[\/]+/_/g' | sed -r 's/[-]+/\\\-/g')/" ${{ github.workspace }}/frontend/sonar-project.properties
     
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,8 +167,8 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        slashreplace=`"${{ github.ref }}" | sed -r 's/[\/]+/\\\//g'`
-        minusreplace=`"$slashreplace" | sed -r 's/[\-]+/\\\-/g'`
+        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g')
+        minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g')
         sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" sonar-project.properties
         # sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,7 +167,7 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem-web-frontend-${{ github.ref }}}/" sonar-project.properties
+        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
         # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,7 +167,8 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
+        sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem-web-frontend-${{ github.ref }}}/" sonar-project.properties
+        # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -166,13 +166,9 @@ jobs:
         sed -i 's/\/home\/runner\/work\/ddueruem-web\/ddueruem-web\//\/github\/workspace\//g' sonar-report.xml
         
     - name: Set Sonarqube Project Name
-      run: >
-        slashreplace=$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g') \
-          minusreplace=$(echo "$slashreplace" | sed -r 's/[\-]+/\\\-/g') \
-          sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-fronted\-$minusreplace/" ${{ github.workspace }}/frontend/sonar-project.properties
-        # sed -i "s/\(sonar\.projectKey=\).*\$/\1${ddueruem\-web\-frontend\-${{ github.ref }}}/" sonar-project.properties
-        # sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
-        
+      run: |
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem\-web\-frontend\-$(echo "${{ github.ref }}" | sed -r 's/[\/]+/\\\//g' | sed -r 's/[-]+/\\\-/g')/" ${{ github.workspace }}/frontend/sonar-project.properties
+    
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master
       with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,7 +167,7 @@ jobs:
         
     - name: Set Sonarqube Project Name
       run: |
-        sed -ir "s/^[#]*\s*sonar.projectKey=.*/sonar.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
+        sed -ir "s/^[#]*\s*sonar\.projectKey=.*/sonar\.projectKey=ddueruem-web-frontend-${{ github.ref }}/" sonar-project.properties
         
     - name: SonarQube Scan
       uses: sonarsource/sonarqube-scan-action@master


### PR DESCRIPTION
The query is explained in the issue #116 
I also made it so the pipeline is executed for `push` and `merge_request` for **ALL** branches. This enables developers to check the sonarqube dashboard during development phase.

closes #116