### PR TITLE
fix editing/deleting constraints when highlighted

### DIFF
--- a/frontendVue3/src/classes/Commands/Constraints/EditCommand.js
+++ b/frontendVue3/src/classes/Commands/Constraints/EditCommand.js
@@ -9,11 +9,13 @@ export class EditCommand extends ConstraintCommand {
     }
 
     execute() {
+        this.constraint.rule.removeConstraint();  // Remove Constraints on  outdatet FeaturenodeConstraintItems
         this.constraint.rule = this.newConstraintItem;
         this.constraint.rule.setConstraint(this.constraint);
     }
 
     undo() {
+        this.constraint.rule.removeConstraint(); // Remove Constraints on  outdatet FeaturenodeConstraintItems
         this.constraint.rule = this.oldConstraintItem;
         this.constraint.rule.setConstraint(this.constraint);
     }

--- a/frontendVue3/src/components/Constraints.vue
+++ b/frontendVue3/src/components/Constraints.vue
@@ -177,6 +177,9 @@ export default {
         },
 
         deleteConstraint(constraint) {
+            if(constraint.isHighlighted){ //reset highlight to free up color
+                constraint.toggleHighlighted();
+            }
             const command = new DeleteCommand(this.constraints, constraint);
             this.commandManager.execute(command);
             this.$emit('update-feature-model');

--- a/frontendVue3/src/components/Constraints.vue
+++ b/frontendVue3/src/components/Constraints.vue
@@ -195,10 +195,12 @@ export default {
 
         undo() {
             this.commandManager.undo();
+            this.$emit('update-feature-model');
         },
 
         redo() {
             this.commandManager.redo();
+            this.$emit('update-feature-model');
         },
     },
 

--- a/frontendVue3/src/components/Constraints.vue
+++ b/frontendVue3/src/components/Constraints.vue
@@ -173,11 +173,13 @@ export default {
             }
             this.closeAddEditDialog();
             this.commandManager.execute(command);
+            this.$emit('update-feature-model');
         },
 
         deleteConstraint(constraint) {
             const command = new DeleteCommand(this.constraints, constraint);
             this.commandManager.execute(command);
+            this.$emit('update-feature-model');
         },
 
         openAddEditDialog(mode, constraint) {


### PR DESCRIPTION
Trying to fix #344  and #345 with this PR.

Took some time to realize that the update event has to be emitted each time the constraints are edited/deleted.

~~The additional Problem mentioned in #344, with the reserved colors, is still WIP.~~