### PR TITLE
only update d3Data when data not null

### DIFF
--- a/frontendVue3/src/classes/Commands/CommandManager.js
+++ b/frontendVue3/src/classes/Commands/CommandManager.js
@@ -112,9 +112,11 @@ export class CommandManager {
 
     fadeOut(d3Data, command) {
         // Rerender for edits and fade them out
-        setTimeout(() => {
-            command.unmarkChanges();
-            update.updateSvg(d3Data);
-        }, 5000);
+        if(this.d3Data){
+            setTimeout(() => {
+                command.unmarkChanges();
+                update.updateSvg(d3Data);
+            }, 5000);
+        }
     }
 }


### PR DESCRIPTION
fix #346.
Problem was that the Command Manager is instantiated 2 times, one for commands regarding the FeatureModel and one for Constraints (where no d3Data is needed).
They offer equal logic, but the fadeOut is only needed when the d3Data is set.
To avoid this error message a simple check beforehand is enough.